### PR TITLE
Support for k8s services and blob storage

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -64,3 +64,14 @@ module "redis" {
   private_endpoint_subnet_id = module.main_vnet.private_endpoint_subnet_id
   key_vault_id               = local.key_vault_id
 }
+
+module "storage" {
+  source = "./modules/storage"
+
+  resource_group_name        = azurerm_resource_group.main.name
+  deployment_name            = var.deployment_name
+  location                   = var.location
+  vnet_id                    = module.main_vnet.vnet_id
+  private_endpoint_subnet_id = module.main_vnet.private_endpoint_subnet_id
+  key_vault_id               = local.key_vault_id
+}

--- a/modules/database/main.tf
+++ b/modules/database/main.tf
@@ -1,5 +1,6 @@
 locals {
-  db_name = "${var.deployment_name}-database"
+  db_name    = "${var.deployment_name}-database"
+  pg_db_name = "braintrust"
 }
 
 resource "azurerm_postgresql_flexible_server" "main" {
@@ -48,7 +49,7 @@ resource "azurerm_postgresql_flexible_server" "main" {
 }
 
 resource "azurerm_postgresql_flexible_server_database" "main" {
-  name      = "braintrust"
+  name      = local.pg_db_name
   server_id = azurerm_postgresql_flexible_server.main.id
   charset   = "UTF8"
   collation = "en_US.utf8"

--- a/modules/database/outputs.tf
+++ b/modules/database/outputs.tf
@@ -8,6 +8,11 @@ output "postgres_database_fqdn" {
   description = "FQDN of the PostgreSQL database"
 }
 
+output "postgres_database_name" {
+  value       = local.pg_db_name
+  description = "Name of the PostgreSQL database"
+}
+
 output "postgres_database_username" {
   value       = azurerm_postgresql_flexible_server.main.administrator_login
   description = "Username for the PostgreSQL database"

--- a/modules/database/outputs.tf
+++ b/modules/database/outputs.tf
@@ -23,6 +23,11 @@ output "postgres_password_secret_id" {
   description = "ID of the Key Vault secret for the PostgreSQL database"
 }
 
+output "postgres_password_secret_name" {
+  description = "The name of the Key Vault secret for the PostgreSQL database"
+  value       = azurerm_key_vault_secret.postgres_password.name
+}
+
 output "postgres_application_security_group_name" {
   value       = azurerm_application_security_group.main_db_endpoint.name
   description = "Name of the postgres application security group"

--- a/modules/redis/outputs.tf
+++ b/modules/redis/outputs.tf
@@ -18,6 +18,11 @@ output "redis_password_secret_id" {
   value       = azurerm_key_vault_secret.redis_password.id
 }
 
+output "redis_password_secret_name" {
+  description = "The name of the Key Vault secret for the Redis Cache password"
+  value       = azurerm_key_vault_secret.redis_password.name
+}
+
 output "redis_application_security_group_name" {
   value       = azurerm_application_security_group.main_redis_endpoint.name
   description = "Name of the redis application security group"

--- a/modules/redis/outputs.tf
+++ b/modules/redis/outputs.tf
@@ -13,16 +13,9 @@ output "redis_ssl_port" {
   value       = azurerm_redis_cache.redis.ssl_port
 }
 
-output "redis_password" {
-  description = "The primary access key for the Redis Cache"
-  value       = azurerm_redis_cache.redis.primary_access_key
-  sensitive   = true
-}
-
-output "redis_connection_string" {
-  description = "The connection string for the Redis Cache"
-  value       = "rediss://:${azurerm_redis_cache.redis.primary_access_key}@${azurerm_redis_cache.redis.hostname}:${azurerm_redis_cache.redis.ssl_port}"
-  sensitive   = true
+output "redis_password_secret_id" {
+  description = "The ID of the Key Vault secret for the Redis Cache password"
+  value       = azurerm_key_vault_secret.redis_password.id
 }
 
 output "redis_application_security_group_name" {

--- a/modules/storage/main.tf
+++ b/modules/storage/main.tf
@@ -1,0 +1,127 @@
+locals {
+  # Names are highly restrictive for storage accounts. So we have to use a random suffix.
+  # Max 24 chars. Letters & numbers ONLY
+  storage_account_name  = "btstorage${random_string.storage_account_suffix.result}"
+  key_name              = "${var.deployment_name}-storage-key"
+  private_dns_zone_name = "privatelink.blob.core.windows.net"
+}
+
+resource "random_string" "storage_account_suffix" {
+  length  = 6
+  special = false
+  upper   = false
+}
+
+resource "azurerm_key_vault_key" "storage" {
+  name         = local.key_name
+  key_vault_id = var.key_vault_id
+  key_type     = "RSA"
+  key_size     = 4096
+  key_opts     = ["decrypt", "encrypt", "sign", "unwrapKey", "verify", "wrapKey"]
+}
+
+resource "azurerm_user_assigned_identity" "storage" {
+  name                = "${var.deployment_name}-${local.storage_account_name}-id"
+  resource_group_name = var.resource_group_name
+  location            = var.location
+}
+
+resource "azurerm_key_vault_access_policy" "storage_identity" {
+  key_vault_id = var.key_vault_id
+  tenant_id    = data.azurerm_client_config.current.tenant_id
+  object_id    = azurerm_user_assigned_identity.storage.principal_id
+
+  key_permissions = [
+    "Get",
+    "UnwrapKey",
+    "WrapKey"
+  ]
+}
+
+resource "azurerm_storage_account" "main" {
+  name                       = local.storage_account_name
+  resource_group_name        = var.resource_group_name
+  location                   = var.location
+  account_tier               = "Premium"
+  account_replication_type   = "ZRS"
+  access_tier                = "Hot"
+  min_tls_version            = "TLS1_2"
+  https_traffic_only_enabled = true
+
+  infrastructure_encryption_enabled = false
+  shared_access_key_enabled         = false
+  public_network_access_enabled     = true
+  blob_properties {
+    versioning_enabled  = false
+    change_feed_enabled = false
+  }
+
+  identity {
+    type         = "UserAssigned"
+    identity_ids = [azurerm_user_assigned_identity.storage.id]
+  }
+
+  customer_managed_key {
+    key_vault_key_id          = azurerm_key_vault_key.storage.id
+    user_assigned_identity_id = azurerm_user_assigned_identity.storage.id
+  }
+
+  depends_on = [
+    azurerm_key_vault_access_policy.storage_identity
+  ]
+}
+
+resource "azurerm_storage_container" "brainstore" {
+  name                  = "brainstore"
+  storage_account_name  = azurerm_storage_account.main.name
+  container_access_type = "private"
+}
+
+resource "azurerm_storage_container" "lambda_responses" {
+  name                  = "lambda-responses"
+  storage_account_name  = azurerm_storage_account.main.name
+  container_access_type = "private"
+}
+
+resource "azurerm_storage_container" "code_bundles" {
+  name                  = "code-bundles"
+  storage_account_name  = azurerm_storage_account.main.name
+  container_access_type = "private"
+}
+
+resource "azurerm_private_dns_zone" "blob" {
+  name                = local.private_dns_zone_name
+  resource_group_name = var.resource_group_name
+}
+
+resource "azurerm_private_dns_zone_virtual_network_link" "blob" {
+  name                  = "${local.storage_account_name}-link"
+  resource_group_name   = var.resource_group_name
+  private_dns_zone_name = azurerm_private_dns_zone.blob.name
+  virtual_network_id    = var.vnet_id
+}
+
+resource "azurerm_private_endpoint" "storage" {
+  name                = "${local.storage_account_name}-endpoint"
+  location            = var.location
+  resource_group_name = var.resource_group_name
+  subnet_id           = var.private_endpoint_subnet_id
+
+  private_service_connection {
+    name                           = "${local.storage_account_name}-connection"
+    private_connection_resource_id = azurerm_storage_account.main.id
+    is_manual_connection           = false
+    subresource_names              = ["blob"]
+  }
+  private_dns_zone_group {
+    name                 = "default"
+    private_dns_zone_ids = [azurerm_private_dns_zone.blob.id]
+  }
+
+  depends_on = [
+    azurerm_private_dns_zone.blob,
+    azurerm_private_dns_zone_virtual_network_link.blob
+  ]
+}
+
+data "azurerm_client_config" "current" {}

--- a/modules/storage/outputs.tf
+++ b/modules/storage/outputs.tf
@@ -1,0 +1,44 @@
+output "storage_account_id" {
+  description = "The ID of the storage account"
+  value       = azurerm_storage_account.main.id
+}
+
+output "storage_account_name" {
+  description = "The name of the storage account"
+  value       = azurerm_storage_account.main.name
+}
+
+output "primary_blob_endpoint" {
+  description = "The primary blob endpoint URL"
+  value       = azurerm_storage_account.main.primary_blob_endpoint
+}
+
+output "brainstore_container_name" {
+  description = "The name of the brainstore container"
+  value       = azurerm_storage_container.brainstore.name
+}
+
+output "lambda_responses_container_name" {
+  description = "The name of the lambda-responses container"
+  value       = azurerm_storage_container.lambda_responses.name
+}
+
+output "code_bundles_container_name" {
+  description = "The name of the code-bundles container"
+  value       = azurerm_storage_container.code_bundles.name
+}
+
+output "storage_identity_id" {
+  description = "The ID of the user-assigned managed identity used by the storage account"
+  value       = azurerm_user_assigned_identity.storage.id
+}
+
+output "storage_identity_principal_id" {
+  description = "The principal ID of the user-assigned managed identity used by the storage account"
+  value       = azurerm_user_assigned_identity.storage.principal_id
+}
+
+output "connection_string" {
+  description = "Connection string for use with Azure AD authentication (no account key)"
+  value       = "BlobEndpoint=${azurerm_storage_account.main.primary_blob_endpoint};"
+}

--- a/modules/storage/variables.tf
+++ b/modules/storage/variables.tf
@@ -1,0 +1,29 @@
+variable "resource_group_name" {
+  description = "The name of the resource group in which to create the storage account"
+  type        = string
+}
+
+variable "deployment_name" {
+  description = "The name of the deployment. Used for naming resources."
+  type        = string
+}
+
+variable "location" {
+  description = "The Azure Region in which to create the storage account"
+  type        = string
+}
+
+variable "key_vault_id" {
+  description = "The ID of the Key Vault to use for encryption"
+  type        = string
+}
+
+variable "private_endpoint_subnet_id" {
+  description = "The ID of the subnet to use for the private endpoint"
+  type        = string
+}
+
+variable "vnet_id" {
+  description = "The ID of the virtual network to link with the private DNS zone"
+  type        = string
+}

--- a/versions.tf
+++ b/versions.tf
@@ -1,9 +1,9 @@
 terraform {
-  required_version = ">= 1.9.0"
+  required_version = ">= 1.11.0"
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.0.0"
+      version = ">= 4.23.0"
     }
     random = {
       source  = "hashicorp/random"


### PR DESCRIPTION
Work in progress.

Added blob storage for brainstore, code-bundles, and function responses.

Added initial support for services in k8s (though not the manifests just yet). 

Terraform will inject a k8s namespace, configMap, and secrets into a kubernetes cluster. The manifests will later reference those in their Deployment yaml.

This config uses the new "ephemeral" lookups that help keep secrets out of terraform state. That means **it requires terraform 1.11**