### PR TITLE
Various fixes

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -94,4 +94,12 @@ resource "azurerm_key_vault_secret" "brainstore_license_key" {
   name         = "brainstore-license-key"
   value        = var.brainstore_license_key
   key_vault_id = local.key_vault_id
+  # This is required because some customers can't support including secrets in CI
+  # This lets them use "" and then later manually enter the secret directly into the key vault
+  # If this ever needs to change it can be done by tainting the resource
+  lifecycle {
+    ignore_changes = [
+      value
+    ]
+  }
 }

--- a/modules/database/main.tf
+++ b/modules/database/main.tf
@@ -69,9 +69,8 @@ resource "azurerm_key_vault_secret" "postgres_connection_string" {
 }
 
 resource "random_password" "postgres_password" {
-  length           = 16
-  special          = true
-  override_special = "!#$%&*()-_=+[]{}<>:?"
+  length  = 16
+  special = false
 }
 
 resource "azurerm_key_vault_key" "postgres_cmk" {

--- a/modules/storage/main.tf
+++ b/modules/storage/main.tf
@@ -47,6 +47,7 @@ resource "azurerm_storage_account" "main" {
   infrastructure_encryption_enabled = false
   shared_access_key_enabled         = false
   public_network_access_enabled     = true
+  allow_nested_items_to_be_public   = false
   blob_properties {
     versioning_enabled  = false
     change_feed_enabled = false

--- a/outputs.tf
+++ b/outputs.tf
@@ -162,5 +162,3 @@ output "key_vault_application_security_group_name" {
   value       = module.kms[0].key_vault_application_security_group_name
   description = "Name of the key vault application security group"
 }
-
-// TDOO expose stoarage account connection string

--- a/versions.tf
+++ b/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 4.23.0"
+      version = ">= 4.27.0"
     }
     random = {
       source  = "hashicorp/random"


### PR DESCRIPTION
* Ignore changes to brainstore license value (see comment)
* No special chars for pg password since it generates invalid connection string URIs
* Dont allow nested items in the storage account to be made public