### PR TITLE
Update variables.tf

### DIFF
--- a/modules/storage/variables.tf
+++ b/modules/storage/variables.tf
@@ -30,6 +30,6 @@ variable "vnet_id" {
 
 variable "create_storage_container" {
   description = "Create containers for the blobstorage. Defaults to true. Disable this if CI CD cannot reach the storage APIs."
-  type        = boolean
+  type        = bool
   default     = true
 }


### PR DESCRIPTION
Error: Invalid type specification

  on braintrust_dataplane_azure/modules/storage/variables.tf line 33, in variable "create_storage_container":
  33:   type        = boolean

The keyword "boolean" is not a valid type specification.