### PR TITLE
Apply verified MAI patch

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -72,9 +72,10 @@ module "storage" {
   resource_group_name        = azurerm_resource_group.main.name
   deployment_name            = var.deployment_name
   location                   = var.location
-  vnet_id                    = module.main_vnet[0].vnet_id
-  private_endpoint_subnet_id = module.main_vnet[0].private_endpoint_subnet_id
+  vnet_id                    = var.existing_vnet.id == "" ? module.main_vnet[0].vnet_id : var.existing_vnet.id
+  private_endpoint_subnet_id = var.existing_vnet.id == "" ? module.main_vnet[0].private_endpoint_subnet_id : var.existing_vnet.private_endpoint_subnet_id
   key_vault_id               = local.key_vault_id
+  create_storage_container   = var.create_storage_container
 }
 
 # Used for encrypting function env secrets. Function environment secrets can be specified

--- a/modules/database/main.tf
+++ b/modules/database/main.tf
@@ -101,3 +101,8 @@ resource "azurerm_postgresql_flexible_server_configuration" "allow_extensions" {
   value     = "pg_stat_statements,pg_hint_plan,pg_cron"
 }
 
+resource "azurerm_postgresql_flexible_server_configuration" "pg_cron_db" {
+  name      = "cron.database_name"
+  server_id = azurerm_postgresql_flexible_server.main.id
+  value     = "braintrust"
+}

--- a/modules/storage/main.tf
+++ b/modules/storage/main.tf
@@ -66,7 +66,7 @@ resource "azurerm_storage_account" "main" {
 }
 
 resource "azurerm_storage_container" "brainstore" {
-  count = vars.create_storage_container ? 1 : 0
+  count = var.create_storage_container ? 1 : 0
 
   name                  = "brainstore"
   storage_account_id    = azurerm_storage_account.main.id
@@ -74,7 +74,7 @@ resource "azurerm_storage_container" "brainstore" {
 }
 
 resource "azurerm_storage_container" "responses" {
-  count = vars.create_storage_container ? 1 : 0
+  count = var.create_storage_container ? 1 : 0
 
   name                  = "responses"
   storage_account_id    = azurerm_storage_account.main.id
@@ -82,7 +82,7 @@ resource "azurerm_storage_container" "responses" {
 }
 
 resource "azurerm_storage_container" "code_bundles" {
-  count = vars.create_storage_container ? 1 : 0
+  count = var.create_storage_container ? 1 : 0
 
   name                  = "code-bundles"
   storage_account_id    = azurerm_storage_account.main.id

--- a/modules/storage/outputs.tf
+++ b/modules/storage/outputs.tf
@@ -15,17 +15,17 @@ output "primary_blob_endpoint" {
 
 output "brainstore_container_name" {
   description = "The name of the brainstore container"
-  value       = vars.create_storage_container ? azurerm_storage_container.brainstore.name : ""
+  value       = var.create_storage_container ? azurerm_storage_container.brainstore[0].name : ""
 }
 
 output "responses_container_name" {
   description = "The name of the responses container"
-  value       = vars.create_storage_container ? azurerm_storage_container.responses.name : ""
+  value       = var.create_storage_container ? azurerm_storage_container.responses[0].name : ""
 }
 
 output "code_bundles_container_name" {
   description = "The name of the code-bundles container"
-  value       = vars.create_storage_container ? azurerm_storage_container.code_bundles.name : ""
+  value       = var.create_storage_container ? azurerm_storage_container.code_bundles[0].name : ""
 }
 
 output "storage_identity_id" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -24,7 +24,7 @@ output "services_subnet_id" {
 }
 
 output "services_network_security_group_id" {
-  value       = var.existing_vnet.id == "" ? module.main_vnet[0].services_network_security_group_id : var.existing_vnet.services_network_security_group_id
+  value       = var.existing_vnet.id == "" ? module.main_vnet[0].services_network_security_group_id : ""
   description = "ID of the services network security group"
 }
 
@@ -144,21 +144,21 @@ output "storage_identity_principal_id" {
 }
 
 output "key_vault_id" {
-  value       = module.kms[0].key_vault_id
+  value       = var.key_vault_id == null ? module.kms[0].key_vault_id : var.key_vault_id
   description = "The ID of the Key Vault"
 }
 
 output "key_vault_name" {
-  value       = module.kms[0].key_vault_name
+  value       = var.key_vault_id == null ? module.kms[0].key_vault_name : ""
   description = "The name of the Key Vault"
 }
 
 output "key_vault_uri" {
-  value       = module.kms[0].key_vault_uri
+  value       = var.key_vault_id == null ? module.kms[0].key_vault_uri : ""
   description = "The URI of the Key Vault"
 }
 
 output "key_vault_application_security_group_name" {
-  value       = module.kms[0].key_vault_application_security_group_name
+  value       = var.key_vault_id == null ? module.kms[0].key_vault_application_security_group_name : ""
   description = "Name of the key vault application security group"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -37,16 +37,20 @@ variable "brainstore_license_key" {
 
 variable "existing_vnet" {
   type = object({
-    id                         = string
-    name                       = string
-    services_subnet_id         = string
-    private_endpoint_subnet_id = string
+    id                                         = string
+    name                                       = string
+    services_subnet_id                         = string
+    private_endpoint_subnet_id                 = string
+    private_endpoint_network_security_group_id = string
+    address_space                              = string
   })
   default = {
-    id                         = ""
-    name                       = ""
-    services_subnet_id         = ""
-    private_endpoint_subnet_id = ""
+    id                                         = ""
+    name                                       = ""
+    services_subnet_id                         = ""
+    private_endpoint_subnet_id                 = ""
+    private_endpoint_network_security_group_id = ""
+    address_space                              = ""
   }
 }
 
@@ -119,6 +123,9 @@ variable "redis_version" {
   default     = "6"
 }
 
-
-
-
+## Storage
+variable "create_storage_container" {
+  description = "Create containers for the blobstorage. Defaults to true. Disable this if CI CD cannot reach the storage APIs."
+  type        = bool
+  default     = true
+}


### PR DESCRIPTION
These changes are currently the diff between BT main and MAI, so we would like to merge these changes into BT main and re-sync in MAI

- Add configs to `existing_vnet` var and use it if it's set
- Allow disabling storage creation (MAI needs this until BT can move storage container logic from tf to application logic)
- Configures Postgre cron job extension (need this to ensure cronjobs in postgres run against braintrust namespace)