### PR TITLE
Add support for launching an AKS cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,20 @@
 # Braintrust Data Plane for Azure
 
-This Terraform module deploys the Braintrust data plane on Azure. It creates all the necessary infrastructure to run Braintrust in your own Azure subscription.
+This Terraform module deploys the Braintrust data plane on Azure. It creates all the necessary core infrastructure to run Braintrust in your own Azure subscription.
 
-## Architecture
+After spinning up the data plane, you will need to deploy the Braintrust services to the AKS cluster using the [Braintrust Helm chart](https://github.com/braintrustdata/helm/tree/main/braintrust).
 
-This module creates the following resources:
-- Azure Resource Group
-- Virtual Networks (Main and Quarantine)
+## Resources
+
+This module creates the following resources by default:
+- Virtual Network
+- Azure Key Vault for encryption and secrets management
 - Azure Database for PostgreSQL
 - Azure Cache for Redis
-- Azure App Service for API handlers
-- Azure Key Vault for secrets management
+- Azure Storage Account for blob storage
+- AKS Kubernetes Cluster
+
+The VNet and AKS cluster can be optionally disabled so you can bring your own network and cluster.
 
 ## Usage
 
@@ -21,5 +25,6 @@ module "braintrust_data_plane" {
   braintrust_org_name = "your-org-name"
   deployment_name     = "braintrust"
   location            = "eastus2"
+  create_aks_cluster  = true
 }
 ```

--- a/main.tf
+++ b/main.tf
@@ -41,6 +41,7 @@ module "k8s" {
   source = "./modules/k8s"
   count  = var.create_aks_cluster ? 1 : 0
 
+  deployment_name     = var.deployment_name
   resource_group_name = azurerm_resource_group.main.name
   vnet_name           = local.vnet_name
   services_subnet_id  = local.services_subnet_id

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,7 @@
 locals {
-  key_vault_id = var.key_vault_id != null ? var.key_vault_id : module.kms[0].key_vault_id
+  key_vault_id               = var.key_vault_id != null ? var.key_vault_id : module.kms[0].key_vault_id
+  vnet_id                    = var.existing_vnet.id == "" ? module.main_vnet[0].vnet_id : var.existing_vnet.id
+  private_endpoint_subnet_id = var.existing_vnet.id == "" ? module.main_vnet[0].private_endpoint_subnet_id : var.existing_vnet.private_endpoint_subnet_id
 }
 
 resource "azurerm_resource_group" "main" {
@@ -14,8 +16,8 @@ module "kms" {
   deployment_name            = var.deployment_name
   resource_group_name        = azurerm_resource_group.main.name
   location                   = var.location
-  virtual_network_id         = var.existing_vnet.id == "" ? module.main_vnet[0].vnet_id : var.existing_vnet.id
-  private_endpoint_subnet_id = var.existing_vnet.id == "" ? module.main_vnet[0].private_endpoint_subnet_id : var.existing_vnet.private_endpoint_subnet_id
+  virtual_network_id         = local.vnet_id
+  private_endpoint_subnet_id = local.private_endpoint_subnet_id
 }
 
 module "main_vnet" {
@@ -44,8 +46,8 @@ module "database" {
   postgres_version      = var.postgres_version
   postgres_storage_tier = var.postgres_storage_tier
 
-  vnet_id                    = var.existing_vnet.id == "" ? module.main_vnet[0].vnet_id : var.existing_vnet.id
-  private_endpoint_subnet_id = var.existing_vnet.id == "" ? module.main_vnet[0].private_endpoint_subnet_id : var.existing_vnet.private_endpoint_subnet_id
+  vnet_id                    = local.vnet_id
+  private_endpoint_subnet_id = local.private_endpoint_subnet_id
   key_vault_id               = local.key_vault_id
 }
 
@@ -61,8 +63,8 @@ module "redis" {
   redis_capacity = var.redis_capacity
   redis_version  = var.redis_version
 
-  virtual_network_id         = var.existing_vnet.id == "" ? module.main_vnet[0].vnet_id : var.existing_vnet.id
-  private_endpoint_subnet_id = var.existing_vnet.id == "" ? module.main_vnet[0].private_endpoint_subnet_id : var.existing_vnet.private_endpoint_subnet_id
+  virtual_network_id         = local.vnet_id
+  private_endpoint_subnet_id = local.private_endpoint_subnet_id
   key_vault_id               = local.key_vault_id
 }
 
@@ -72,8 +74,8 @@ module "storage" {
   resource_group_name        = azurerm_resource_group.main.name
   deployment_name            = var.deployment_name
   location                   = var.location
-  vnet_id                    = var.existing_vnet.id == "" ? module.main_vnet[0].vnet_id : var.existing_vnet.id
-  private_endpoint_subnet_id = var.existing_vnet.id == "" ? module.main_vnet[0].private_endpoint_subnet_id : var.existing_vnet.private_endpoint_subnet_id
+  vnet_id                    = local.vnet_id
+  private_endpoint_subnet_id = local.private_endpoint_subnet_id
   key_vault_id               = local.key_vault_id
   create_storage_container   = var.create_storage_container
 }

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,9 @@
 locals {
   key_vault_id               = var.key_vault_id != null ? var.key_vault_id : module.kms[0].key_vault_id
   vnet_id                    = var.existing_vnet.id == "" ? module.main_vnet[0].vnet_id : var.existing_vnet.id
+  vnet_name                  = var.existing_vnet.id == "" ? module.main_vnet[0].vnet_name : var.existing_vnet.name
+  vnet_address_space         = var.existing_vnet.id == "" ? module.main_vnet[0].vnet_address_space : var.existing_vnet.address_space
+  services_subnet_id         = var.existing_vnet.id == "" ? module.main_vnet[0].services_subnet_id : var.existing_vnet.services_subnet_id
   private_endpoint_subnet_id = var.existing_vnet.id == "" ? module.main_vnet[0].private_endpoint_subnet_id : var.existing_vnet.private_endpoint_subnet_id
 }
 
@@ -32,6 +35,15 @@ module "main_vnet" {
   vnet_address_space_cidr      = var.vnet_address_space_cidr
   services_subnet_cidr         = var.services_subnet_cidr
   private_endpoint_subnet_cidr = var.private_endpoint_subnet_cidr
+}
+
+module "k8s" {
+  source = "./modules/k8s"
+  count  = var.create_aks_cluster ? 1 : 0
+
+  resource_group_name = azurerm_resource_group.main.name
+  vnet_name           = local.vnet_name
+  services_subnet_id  = local.services_subnet_id
 }
 
 module "database" {

--- a/main.tf
+++ b/main.tf
@@ -45,6 +45,9 @@ module "k8s" {
   resource_group_name = azurerm_resource_group.main.name
   vnet_name           = local.vnet_name
   services_subnet_id  = local.services_subnet_id
+  vm_size             = var.aks_user_vm_size
+  system_vm_size      = var.aks_system_vm_size
+  location            = var.location
 }
 
 module "database" {

--- a/main.tf
+++ b/main.tf
@@ -45,8 +45,9 @@ module "k8s" {
   resource_group_name = azurerm_resource_group.main.name
   vnet_name           = local.vnet_name
   services_subnet_id  = local.services_subnet_id
-  vm_size             = var.aks_user_vm_size
-  system_vm_size      = var.aks_system_vm_size
+  user_pool_vm_size   = var.aks_user_pool_vm_size
+  user_pool_max_count = var.aks_user_pool_max_count
+  system_pool_vm_size = var.aks_system_pool_vm_size
   location            = var.location
 }
 

--- a/modules/k8s/main.tf
+++ b/modules/k8s/main.tf
@@ -21,6 +21,7 @@ resource "azurerm_role_assignment" "aks_identity" {
   for_each = toset([
     "Contributor",
     "Azure Kubernetes Service RBAC Cluster Admin",
+    "Key Vault Secrets User"
   ])
   scope                = data.azurerm_resource_group.main.id
   role_definition_name = each.value

--- a/modules/k8s/main.tf
+++ b/modules/k8s/main.tf
@@ -88,15 +88,16 @@ resource "azurerm_kubernetes_cluster" "aks" {
 }
 
 resource "azurerm_kubernetes_cluster_node_pool" "user" {
-  kubernetes_cluster_id = azurerm_kubernetes_cluster.aks.id
-  auto_scaling_enabled  = true
-  name                  = "user"
-  mode                  = "User"
-  min_count             = 2
-  max_count             = 10
-  node_count            = 2
-  vm_size               = var.vm_size
-  vnet_subnet_id        = var.services_subnet_id
+  kubernetes_cluster_id       = azurerm_kubernetes_cluster.aks.id
+  auto_scaling_enabled        = true
+  name                        = "user"
+  mode                        = "User"
+  min_count                   = 2
+  max_count                   = 10
+  node_count                  = 2
+  vm_size                     = var.vm_size
+  vnet_subnet_id              = var.services_subnet_id
+  temporary_name_for_rotation = "userrotate"
 }
 
 resource "azurerm_federated_identity_credential" "braintrust_api" {

--- a/modules/k8s/main.tf
+++ b/modules/k8s/main.tf
@@ -98,6 +98,12 @@ resource "azurerm_kubernetes_cluster_node_pool" "user" {
   vm_size                     = var.user_pool_vm_size
   vnet_subnet_id              = var.services_subnet_id
   temporary_name_for_rotation = "userrotate"
+
+  lifecycle {
+    ignore_changes = [
+      node_count
+    ]
+  }
 }
 
 

--- a/modules/k8s/main.tf
+++ b/modules/k8s/main.tf
@@ -1,3 +1,7 @@
+locals {
+  cluster_name = "${var.deployment_name}-${var.cluster_name}"
+}
+
 data "azurerm_resource_group" "main" {
   name = var.resource_group_name
 }
@@ -10,7 +14,7 @@ data "azurerm_virtual_network" "main" {
 resource "azurerm_user_assigned_identity" "aks_identity" {
   resource_group_name = data.azurerm_resource_group.main.name
   location            = data.azurerm_resource_group.main.location
-  name                = "${var.cluster_name}-identity"
+  name                = "${local.cluster_name}-identity"
 }
 
 resource "azurerm_role_assignment" "aks_identity" {
@@ -27,7 +31,7 @@ resource "azurerm_role_assignment" "aks_identity" {
 resource "azurerm_kubernetes_cluster" "aks" {
   location            = data.azurerm_resource_group.main.location
   resource_group_name = data.azurerm_resource_group.main.name
-  name                = var.cluster_name
+  name                = local.cluster_name
   identity {
     type = "UserAssigned"
     identity_ids = [
@@ -57,7 +61,7 @@ resource "azurerm_kubernetes_cluster" "aks" {
 
   oidc_issuer_enabled = true
 
-  dns_prefix = var.cluster_name
+  dns_prefix = local.cluster_name
   # private_cluster_enabled             = false
   # private_cluster_public_fqdn_enabled = false
   # private_dns_zone_id                 = azurerm_private_dns_zone.aks.id

--- a/modules/k8s/main.tf
+++ b/modules/k8s/main.tf
@@ -98,6 +98,24 @@ resource "azurerm_kubernetes_cluster_node_pool" "user" {
   vnet_subnet_id        = var.services_subnet_id
 }
 
+resource "azurerm_federated_identity_credential" "braintrust_api" {
+  name                = "${local.cluster_name}-braintrust-api"
+  resource_group_name = data.azurerm_resource_group.main.name
+  audience            = ["api://AzureADTokenExchange"]
+  issuer              = azurerm_kubernetes_cluster.aks.oidc_issuer_url
+  parent_id           = azurerm_user_assigned_identity.aks_identity.id
+  subject             = "system:serviceaccount:braintrust:braintrust-api"
+}
+
+resource "azurerm_federated_identity_credential" "brainstore" {
+  name                = "${local.cluster_name}-brainstore"
+  resource_group_name = data.azurerm_resource_group.main.name
+  audience            = ["api://AzureADTokenExchange"]
+  issuer              = azurerm_kubernetes_cluster.aks.oidc_issuer_url
+  parent_id           = azurerm_user_assigned_identity.aks_identity.id
+  subject             = "system:serviceaccount:braintrust:brainstore"
+}
+
 # resource "azurerm_private_dns_zone" "aks" {
 #   resource_group_name = var.resource_group_name
 #   name                = "privatelink.${data.azurerm_resource_group.main.location}.azmk8s.io"

--- a/modules/k8s/main.tf
+++ b/modules/k8s/main.tf
@@ -1,82 +1,78 @@
-resource "azurerm_log_analytics_workspace" "aks" {
-  name                = "${var.cluster_name}-log-analytics"
-  location            = azurerm_resource_group.aks.location
-  resource_group_name = azurerm_resource_group.aks.name
-  sku                 = "PerGB2018"
-  retention_in_days   = 30
+data "azurerm_resource_group" "main" {
+  name = var.resource_group_name
+}
+
+data "azurerm_virtual_network" "main" {
+  name                = var.vnet_name
+  resource_group_name = var.resource_group_name
 }
 
 resource "azurerm_user_assigned_identity" "aks_identity" {
-  resource_group_name = azurerm_resource_group.aks.name
-  location            = azurerm_resource_group.aks.location
+  resource_group_name = data.azurerm_resource_group.main.name
+  location            = data.azurerm_resource_group.main.location
   name                = "${var.cluster_name}-identity"
 }
 
-resource "azurerm_role_assignment" "aks_network" {
-  scope                = data.azurerm_subnet.existing.id
-  role_definition_name = "Network Contributor"
+resource "azurerm_role_assignment" "aks_identity" {
+  for_each = toset([
+    "Contributor",
+    "Azure Kubernetes Service RBAC Cluster Admin",
+  ])
+  scope                = data.azurerm_resource_group.main.id
+  role_definition_name = each.value
   principal_id         = azurerm_user_assigned_identity.aks_identity.principal_id
+  principal_type       = "ServicePrincipal"
 }
 
 resource "azurerm_kubernetes_cluster" "aks" {
-  name                      = var.cluster_name
-  location                  = azurerm_resource_group.aks.location
-  resource_group_name       = azurerm_resource_group.aks.name
-  dns_prefix                = var.cluster_name
-  kubernetes_version        = var.kubernetes_version
-  private_cluster_enabled   = false
-  sku_tier                  = "Standard"
-  automatic_channel_upgrade = "stable"
-
-  default_node_pool {
-    name                   = "system"
-    node_count             = 3
-    vm_size                = var.system_vm_size
-    enable_host_encryption = true
-
-    temporary_name_for_rotation = "system-rotating"
-    vnet_subnet_id              = var.services_subnet_id
-    orchestrator_version        = var.kubernetes_version
-    os_sku                      = "Ubuntu"
-    os_disk_size_gb             = 50
-    os_disk_type                = "Managed"
-    type                        = "VirtualMachineScaleSets"
-    # enable_auto_scaling         = true
-    # min_count                   = 2
-    # max_count                   = 3
-    # max_pods                    = 30
-  }
-
+  location            = data.azurerm_resource_group.main.location
+  resource_group_name = data.azurerm_resource_group.main.name
+  name                = var.cluster_name
   identity {
     type = "UserAssigned"
     identity_ids = [
-      azurerm_user_assigned_identity.aks_identity.id
+      azurerm_user_assigned_identity.aks_identity.id,
     ]
   }
 
-  # Network profile
-  network_profile {
-    network_plugin    = "azure"
-    load_balancer_sku = "standard"
-    outbound_type     = "loadBalancer"
-    network_policy    = "calico"
-  }
-
-  oms_agent {
-    log_analytics_workspace_id = azurerm_log_analytics_workspace.aks.id
-  }
-
-  azure_policy_enabled = true
-
-  linux_profile {
-    admin_username = "azure"
-    ssh_key {
-      key_data = var.ssh_public_key
+  sku_tier = "Standard"
+  default_node_pool {
+    name                 = "nodepool"
+    vm_size              = var.system_vm_size
+    node_count           = 3
+    min_count            = 3
+    max_count            = 6
+    auto_scaling_enabled = true
+    vnet_subnet_id       = var.services_subnet_id
+    upgrade_settings {
+      drain_timeout_in_minutes      = 0
+      max_surge                     = "10%"
+      node_soak_duration_in_minutes = 0
     }
   }
 
-  azure_active_directory_role_based_access_control {
-    azure_rbac_enabled = true
+  key_vault_secrets_provider {
+    secret_rotation_enabled = true
+  }
+
+  oidc_issuer_enabled = true
+
+  dns_prefix = var.cluster_name
+  # private_cluster_enabled             = false
+  # private_cluster_public_fqdn_enabled = false
+  # private_dns_zone_id                 = azurerm_private_dns_zone.aks.id
+  workload_identity_enabled = true
+
+  storage_profile {
+    blob_driver_enabled         = true
+    disk_driver_enabled         = false
+    file_driver_enabled         = false
+    snapshot_controller_enabled = false
+  }
+
+  monitor_metrics {
+    annotations_allowed = null
+    labels_allowed      = "nodes=[*]"
   }
 
   lifecycle {
@@ -86,23 +82,27 @@ resource "azurerm_kubernetes_cluster" "aks" {
   }
 }
 
-# Allow SSH login via AAD (Entra ID). Assign a user/group the "Virtual Machine Administrator Login" role and then use `az ssh vm`
-resource "azurerm_virtual_machine_scale_set_extension" "aad_ssh" {
-  name                         = "AADSSHLoginForLinux"
-  virtual_machine_scale_set_id = azurerm_kubernetes_cluster.aks.default_node_pool[0].id
-  publisher                    = "Microsoft.Azure.ActiveDirectory.LinuxSSH"
-  type                         = "AADSSHLoginForLinux"
-  type_handler_version         = "1.0"
-}
-
-resource "azurerm_kubernetes_cluster_node_pool" "services" {
-  name                  = "services"
+resource "azurerm_kubernetes_cluster_node_pool" "user" {
   kubernetes_cluster_id = azurerm_kubernetes_cluster.aks.id
+  auto_scaling_enabled  = true
+  name                  = "user"
+  mode                  = "User"
+  min_count             = 2
+  max_count             = 10
+  node_count            = 2
   vm_size               = var.vm_size
   vnet_subnet_id        = var.services_subnet_id
-  enable_auto_scaling   = true
-  min_count             = 2
-  max_count             = 3
-  max_pods              = 30
-  zones                 = ["1", "2"]
 }
+
+# resource "azurerm_private_dns_zone" "aks" {
+#   resource_group_name = var.resource_group_name
+#   name                = "privatelink.${data.azurerm_resource_group.main.location}.azmk8s.io"
+# }
+
+# resource "azurerm_private_dns_zone_virtual_network_link" "aksdns_in_aksvnet" {
+#   name                  = "aksvnet-akszone"
+#   resource_group_name   = var.resource_group_name
+#   private_dns_zone_name = azurerm_private_dns_zone.aks.name
+#   virtual_network_id    = data.azurerm_virtual_network.main.id
+#   registration_enabled  = false
+# }

--- a/modules/k8s/outputs.tf
+++ b/modules/k8s/outputs.tf
@@ -6,3 +6,11 @@ output "kube_config" {
 output "cluster_name" {
   value = azurerm_kubernetes_cluster.aks.name
 }
+
+output "aks_identity_client_id" {
+  value = azurerm_user_assigned_identity.aks_identity.client_id
+}
+
+output "aks_identity_object_id" {
+  value = azurerm_user_assigned_identity.aks_identity.principal_id
+}

--- a/modules/k8s/outputs.tf
+++ b/modules/k8s/outputs.tf
@@ -1,0 +1,4 @@
+output "aks" {
+  value     = azurerm_kubernetes_cluster.aks
+  sensitive = true
+}

--- a/modules/k8s/outputs.tf
+++ b/modules/k8s/outputs.tf
@@ -1,4 +1,8 @@
-output "aks" {
-  value     = azurerm_kubernetes_cluster.aks
+output "kube_config" {
+  value     = azurerm_kubernetes_cluster.aks.kube_config_raw
   sensitive = true
+}
+
+output "cluster_name" {
+  value = azurerm_kubernetes_cluster.aks.name
 }

--- a/modules/k8s/variables.tf
+++ b/modules/k8s/variables.tf
@@ -11,7 +11,6 @@ variable "deployment_name" {
 variable "location" {
   description = "Azure region"
   type        = string
-  default     = "eastus"
 }
 
 variable "cluster_name" {
@@ -23,7 +22,7 @@ variable "cluster_name" {
 variable "vm_size" {
   description = "VM size for the nodes"
   type        = string
-  default     = "Standard_D16as_v6"
+  default     = "Standard_D16ds_v6"
 }
 
 variable "vnet_name" {

--- a/modules/k8s/variables.tf
+++ b/modules/k8s/variables.tf
@@ -3,6 +3,11 @@ variable "resource_group_name" {
   type        = string
 }
 
+variable "deployment_name" {
+  description = "Name of the deployment"
+  type        = string
+}
+
 variable "location" {
   description = "Azure region"
   type        = string

--- a/modules/k8s/variables.tf
+++ b/modules/k8s/variables.tf
@@ -24,7 +24,7 @@ variable "kubernetes_version" {
 variable "vm_size" {
   description = "VM size for the nodes"
   type        = string
-  default     = "Standard_D2s_v3" # Smaller VM size, good balance of CPU/memory
+  default     = "Standard_D16as_v6"
 }
 
 variable "vnet_name" {
@@ -51,6 +51,6 @@ variable "ssh_public_key" {
 variable "system_vm_size" {
   description = "VM size for the system nodes"
   type        = string
-  default     = "Standard_D2ps_v6"
+  default     = "Standard_D2as_v6"
 }
 

--- a/modules/k8s/variables.tf
+++ b/modules/k8s/variables.tf
@@ -19,10 +19,16 @@ variable "cluster_name" {
   default     = "aks"
 }
 
-variable "vm_size" {
+variable "user_pool_vm_size" {
   description = "VM size for the nodes"
   type        = string
   default     = "Standard_D16ds_v6"
+}
+
+variable "user_pool_max_count" {
+  description = "Maximum number of nodes in the user pool"
+  type        = number
+  default     = 10
 }
 
 variable "vnet_name" {
@@ -35,7 +41,7 @@ variable "services_subnet_id" {
   type        = string
 }
 
-variable "system_vm_size" {
+variable "system_pool_vm_size" {
   description = "VM size for the system nodes"
   type        = string
   default     = "Standard_D2as_v6"

--- a/modules/k8s/variables.tf
+++ b/modules/k8s/variables.tf
@@ -12,13 +12,7 @@ variable "location" {
 variable "cluster_name" {
   description = "Name of the AKS cluster"
   type        = string
-  default     = "aks-small-prod"
-}
-
-variable "kubernetes_version" {
-  description = "Kubernetes version"
-  type        = string
-  default     = "1.28.5"
+  default     = "aks"
 }
 
 variable "vm_size" {
@@ -32,20 +26,9 @@ variable "vnet_name" {
   type        = string
 }
 
-variable "vnet_resource_group_name" {
-  description = "Resource group name of the existing VNet"
-  type        = string
-}
-
 variable "services_subnet_id" {
   description = "ID of the subnet for AKS"
   type        = string
-}
-
-variable "ssh_public_key" {
-  description = "SSH public key for the nodes. "
-  type        = string
-  default     = null
 }
 
 variable "system_vm_size" {

--- a/modules/storage/main.tf
+++ b/modules/storage/main.tf
@@ -29,9 +29,14 @@ resource "azurerm_user_assigned_identity" "storage" {
 }
 
 resource "azurerm_role_assignment" "storage_cmk" {
+  for_each = toset([
+    "Key Vault Crypto User",
+    "Key Vault Crypto Service Encryption User"
+  ])
   scope                = var.key_vault_id
-  role_definition_name = "Key Vault Crypto User"
+  role_definition_name = each.value
   principal_id         = azurerm_user_assigned_identity.storage.principal_id
+  principal_type       = "ServicePrincipal"
 }
 
 resource "azurerm_storage_account" "main" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -172,3 +172,23 @@ output "aks_cluster_name" {
   value       = module.k8s[0].cluster_name
   description = "The AKS cluster name"
 }
+
+output "aks_identity_client_id" {
+  value       = module.k8s[0].aks_identity_client_id
+  description = "The client ID of the AKS identity"
+}
+
+output "aks_identity_object_id" {
+  value       = module.k8s[0].aks_identity_object_id
+  description = "The object ID of the AKS identity"
+}
+
+output "azure_tenant_id" {
+  value       = data.azurerm_client_config.current.tenant_id
+  description = "The tenant ID of the Azure subscription"
+}
+
+output "braintrust_org_name" {
+  value       = var.braintrust_org_name
+  description = "The name of the Braintrust organization"
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -162,3 +162,9 @@ output "key_vault_application_security_group_name" {
   value       = var.key_vault_id == null ? module.kms[0].key_vault_application_security_group_name : ""
   description = "Name of the key vault application security group"
 }
+
+output "aks" {
+  value       = module.k8s[0].aks
+  description = "The AKS cluster"
+  sensitive   = true
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -163,23 +163,24 @@ output "key_vault_application_security_group_name" {
   description = "Name of the key vault application security group"
 }
 
+
 output "kube_config" {
-  value       = module.k8s[0].kube_config
+  value       = var.create_aks_cluster ? module.k8s[0].kube_config : null
   description = "The AKS cluster kubeconfig"
 }
 
 output "aks_cluster_name" {
-  value       = module.k8s[0].cluster_name
+  value       = var.create_aks_cluster ? module.k8s[0].cluster_name : null
   description = "The AKS cluster name"
 }
 
 output "aks_identity_client_id" {
-  value       = module.k8s[0].aks_identity_client_id
+  value       = var.create_aks_cluster ? module.k8s[0].aks_identity_client_id : null
   description = "The client ID of the AKS identity"
 }
 
 output "aks_identity_object_id" {
-  value       = module.k8s[0].aks_identity_object_id
+  value       = var.create_aks_cluster ? module.k8s[0].aks_identity_object_id : null
   description = "The object ID of the AKS identity"
 }
 
@@ -192,3 +193,4 @@ output "braintrust_org_name" {
   value       = var.braintrust_org_name
   description = "The name of the Braintrust organization"
 }
+

--- a/outputs.tf
+++ b/outputs.tf
@@ -163,8 +163,12 @@ output "key_vault_application_security_group_name" {
   description = "Name of the key vault application security group"
 }
 
-output "aks" {
-  value       = module.k8s[0].aks
-  description = "The AKS cluster"
-  sensitive   = true
+output "kube_config" {
+  value       = module.k8s[0].kube_config
+  description = "The AKS cluster kubeconfig"
+}
+
+output "aks_cluster_name" {
+  value       = module.k8s[0].cluster_name
+  description = "The AKS cluster name"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -77,7 +77,8 @@ variable "private_endpoint_subnet_cidr" {
 variable "create_aks_cluster" {
   description = "Create an AKS cluster"
   type        = bool
-  default     = true
+  ## This should be made default on in a future release
+  default = false
 }
 
 variable "aks_system_pool_vm_size" {

--- a/variables.tf
+++ b/variables.tf
@@ -80,6 +80,18 @@ variable "create_aks_cluster" {
   default     = true
 }
 
+variable "aks_system_vm_size" {
+  description = "VM size for the system nodes"
+  type        = string
+  default     = "Standard_D2as_v6"
+}
+
+variable "aks_user_vm_size" {
+  description = "VM size for the user nodes that run the application. Must be a SKU with a temporary local storage SSD."
+  type        = string
+  default     = "Standard_D16ds_v6"
+}
+
 
 ## Database
 variable "postgres_sku_name" {

--- a/variables.tf
+++ b/variables.tf
@@ -73,6 +73,14 @@ variable "private_endpoint_subnet_cidr" {
   default     = null
 }
 
+## AKS
+variable "create_aks_cluster" {
+  description = "Create an AKS cluster"
+  type        = bool
+  default     = true
+}
+
+
 ## Database
 variable "postgres_sku_name" {
   description = "SKU name for the Azure Database for PostgreSQL instance."

--- a/variables.tf
+++ b/variables.tf
@@ -80,16 +80,22 @@ variable "create_aks_cluster" {
   default     = true
 }
 
-variable "aks_system_vm_size" {
+variable "aks_system_pool_vm_size" {
   description = "VM size for the system nodes"
   type        = string
   default     = "Standard_D2as_v6"
 }
 
-variable "aks_user_vm_size" {
+variable "aks_user_pool_vm_size" {
   description = "VM size for the user nodes that run the application. Must be a SKU with a temporary local storage SSD."
   type        = string
   default     = "Standard_D16ds_v6"
+}
+
+variable "aks_user_pool_max_count" {
+  description = "Maximum number of nodes in the user pool"
+  type        = number
+  default     = 10
 }
 
 


### PR DESCRIPTION
Creating an AKS cluster is disabled by default until I can coordinate with existing customers to set `create_aks_cluster=false` in their module declarations