### PR TITLE
Ignore PG storage_tier and storage_mb changes

### DIFF
--- a/modules/database/main.tf
+++ b/modules/database/main.tf
@@ -44,7 +44,9 @@ resource "azurerm_postgresql_flexible_server" "main" {
   lifecycle {
     ignore_changes = [
       high_availability[0].standby_availability_zone,
-      zone
+      zone,
+      storage_mb,
+      storage_tier,
     ]
   }
 }


### PR DESCRIPTION
These auto grow and show up as a plan diff over time. They will only be respected when first creating the PG instance. After that any changes to them will be automatic or will require a manual change in the console.