### PR TITLE
Add global 60m statement timeout

### DIFF
--- a/modules/database/main.tf
+++ b/modules/database/main.tf
@@ -108,3 +108,10 @@ resource "azurerm_postgresql_flexible_server_configuration" "pg_cron_db" {
   server_id = azurerm_postgresql_flexible_server.main.id
   value     = "braintrust"
 }
+
+resource "azurerm_postgresql_flexible_server_configuration" "statement_timeout" {
+  name      = "statement_timeout"
+  server_id = azurerm_postgresql_flexible_server.main.id
+  value     = "3600000"
+}
+


### PR DESCRIPTION
No statement should ever run this long, but there are chances that disconnects or random issues can cause it. Setting a 60m ensures these stuck queries get terminated at some point.