### PR TITLE
Enable additional DB metrics

### DIFF
--- a/modules/database/main.tf
+++ b/modules/database/main.tf
@@ -115,3 +115,15 @@ resource "azurerm_postgresql_flexible_server_configuration" "statement_timeout" 
   value     = "3600000"
 }
 
+resource "azurerm_postgresql_flexible_server_configuration" "collector_database_activity" {
+  name      = "metrics.collector_database_activity"
+  server_id = azurerm_postgresql_flexible_server.main.id
+  value     = "ON"
+}
+
+resource "azurerm_postgresql_flexible_server_configuration" "autovacuum_diagnostics" {
+  name      = "metrics.autovacuum_diagnostics"
+  server_id = azurerm_postgresql_flexible_server.main.id
+  value     = "ON"
+}
+


### PR DESCRIPTION
This will give us extra vacuum and query metrics in the Azure portal for the Postgres database. 