### PR TITLE
Allow Azure users to provide their own private DNS zones

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -66,6 +66,8 @@ module "database" {
   vnet_id                    = local.vnet_id
   private_endpoint_subnet_id = local.private_endpoint_subnet_id
   key_vault_id               = local.key_vault_id
+
+  pg_private_dns_zone_id = var.pg_private_dns_zone_id
 }
 
 module "redis" {
@@ -83,6 +85,8 @@ module "redis" {
   virtual_network_id         = local.vnet_id
   private_endpoint_subnet_id = local.private_endpoint_subnet_id
   key_vault_id               = local.key_vault_id
+
+  redis_private_dns_zone_id = var.redis_private_dns_zone_id
 }
 
 module "storage" {
@@ -95,6 +99,8 @@ module "storage" {
   private_endpoint_subnet_id = local.private_endpoint_subnet_id
   key_vault_id               = local.key_vault_id
   create_storage_container   = var.create_storage_container
+
+  blob_private_dns_zone_id = var.blob_private_dns_zone_id
 }
 
 # Used for encrypting function env secrets. Function environment secrets can be specified

--- a/main.tf
+++ b/main.tf
@@ -67,7 +67,7 @@ module "database" {
   private_endpoint_subnet_id = local.private_endpoint_subnet_id
   key_vault_id               = local.key_vault_id
 
-  pg_private_dns_zone_id = var.pg_private_dns_zone_id
+  existing_postgres_private_dns_zone_id = var.existing_postgres_private_dns_zone_id
 }
 
 module "redis" {
@@ -86,7 +86,7 @@ module "redis" {
   private_endpoint_subnet_id = local.private_endpoint_subnet_id
   key_vault_id               = local.key_vault_id
 
-  redis_private_dns_zone_id = var.redis_private_dns_zone_id
+  existing_redis_private_dns_zone_id = var.existing_redis_private_dns_zone_id
 }
 
 module "storage" {
@@ -100,7 +100,7 @@ module "storage" {
   key_vault_id               = local.key_vault_id
   create_storage_container   = var.create_storage_container
 
-  blob_private_dns_zone_id = var.blob_private_dns_zone_id
+  existing_blob_private_dns_zone_id = var.existing_blob_private_dns_zone_id
 }
 
 # Used for encrypting function env secrets. Function environment secrets can be specified

--- a/modules/database/privatelink.tf
+++ b/modules/database/privatelink.tf
@@ -1,12 +1,14 @@
 resource "azurerm_private_dns_zone" "main" {
+  count               = var.pg_private_dns_zone_id == "" ? 1 : 0
   name                = "privatelink.postgres.database.azure.com"
   resource_group_name = var.resource_group_name
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "main" {
+  count                 = var.pg_private_dns_zone_id == "" ? 1 : 0
   name                  = local.db_name
   resource_group_name   = var.resource_group_name
-  private_dns_zone_name = azurerm_private_dns_zone.main.name
+  private_dns_zone_name = azurerm_private_dns_zone.main[0].name
   virtual_network_id    = var.vnet_id
 }
 
@@ -18,7 +20,7 @@ resource "azurerm_private_endpoint" "main" {
 
   private_dns_zone_group {
     name                 = local.db_name
-    private_dns_zone_ids = [azurerm_private_dns_zone.main.id]
+    private_dns_zone_ids = [var.pg_private_dns_zone_id != "" ? var.pg_private_dns_zone_id : azurerm_private_dns_zone.main[0].id]
   }
 
   private_service_connection {

--- a/modules/database/privatelink.tf
+++ b/modules/database/privatelink.tf
@@ -1,11 +1,11 @@
 resource "azurerm_private_dns_zone" "main" {
-  count               = var.pg_private_dns_zone_id == "" ? 1 : 0
+  count               = var.existing_postgres_private_dns_zone_id == "" ? 1 : 0
   name                = "privatelink.postgres.database.azure.com"
   resource_group_name = var.resource_group_name
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "main" {
-  count                 = var.pg_private_dns_zone_id == "" ? 1 : 0
+  count                 = var.existing_postgres_private_dns_zone_id == "" ? 1 : 0
   name                  = local.db_name
   resource_group_name   = var.resource_group_name
   private_dns_zone_name = azurerm_private_dns_zone.main[0].name
@@ -20,7 +20,7 @@ resource "azurerm_private_endpoint" "main" {
 
   private_dns_zone_group {
     name                 = local.db_name
-    private_dns_zone_ids = [var.pg_private_dns_zone_id != "" ? var.pg_private_dns_zone_id : azurerm_private_dns_zone.main[0].id]
+    private_dns_zone_ids = [var.existing_postgres_private_dns_zone_id != "" ? var.existing_postgres_private_dns_zone_id : azurerm_private_dns_zone.main[0].id]
   }
 
   private_service_connection {

--- a/modules/database/variables.tf
+++ b/modules/database/variables.tf
@@ -52,3 +52,8 @@ variable "key_vault_id" {
   description = "The ID of the Key Vault to use for database encryption and secrets"
   type        = string
 }
+
+variable "pg_private_dns_zone_id" {
+  description = "The ID of the existing private dns zone"
+  type        = string
+}

--- a/modules/database/variables.tf
+++ b/modules/database/variables.tf
@@ -53,7 +53,8 @@ variable "key_vault_id" {
   type        = string
 }
 
-variable "pg_private_dns_zone_id" {
-  description = "The ID of the existing private dns zone"
+variable "existing_postgres_private_dns_zone_id" {
+  description = "Advanced: Use an existing private dns zone id for postgres private endpoint. Only needed if you want to deploy two data planes into the same VNet. Leave blank to auto-create one."
   type        = string
+  default     = ""
 }

--- a/modules/redis/privatelink.tf
+++ b/modules/redis/privatelink.tf
@@ -7,7 +7,7 @@ resource "azurerm_private_endpoint" "redis" {
 
   private_dns_zone_group {
     name                 = "redis"
-    private_dns_zone_ids = [azurerm_private_dns_zone.redis.id]
+    private_dns_zone_ids = [var.redis_private_dns_zone_id != "" ? var.redis_private_dns_zone_id : azurerm_private_dns_zone.redis[0].id]
   }
 
   private_service_connection {
@@ -20,13 +20,15 @@ resource "azurerm_private_endpoint" "redis" {
 
 resource "azurerm_private_dns_zone" "redis" {
   # https://learn.microsoft.com/en-us/azure/private-link/private-endpoint-dns
+  count               = var.redis_private_dns_zone_id == "" ? 1 : 0
   name                = "redis.cache.windows.net"
   resource_group_name = var.resource_group_name
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "redis" {
+  count                 = var.redis_private_dns_zone_id == "" ? 1 : 0
   name                  = "redis"
-  private_dns_zone_name = azurerm_private_dns_zone.redis.name
+  private_dns_zone_name = azurerm_private_dns_zone.redis[0].name
   virtual_network_id    = var.virtual_network_id
   resource_group_name   = var.resource_group_name
 }

--- a/modules/redis/privatelink.tf
+++ b/modules/redis/privatelink.tf
@@ -7,7 +7,7 @@ resource "azurerm_private_endpoint" "redis" {
 
   private_dns_zone_group {
     name                 = "redis"
-    private_dns_zone_ids = [var.redis_private_dns_zone_id != "" ? var.redis_private_dns_zone_id : azurerm_private_dns_zone.redis[0].id]
+    private_dns_zone_ids = [var.existing_redis_private_dns_zone_id != "" ? var.existing_redis_private_dns_zone_id : azurerm_private_dns_zone.redis[0].id]
   }
 
   private_service_connection {
@@ -20,13 +20,13 @@ resource "azurerm_private_endpoint" "redis" {
 
 resource "azurerm_private_dns_zone" "redis" {
   # https://learn.microsoft.com/en-us/azure/private-link/private-endpoint-dns
-  count               = var.redis_private_dns_zone_id == "" ? 1 : 0
+  count               = var.existing_redis_private_dns_zone_id == "" ? 1 : 0
   name                = "redis.cache.windows.net"
   resource_group_name = var.resource_group_name
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "redis" {
-  count                 = var.redis_private_dns_zone_id == "" ? 1 : 0
+  count                 = var.existing_redis_private_dns_zone_id == "" ? 1 : 0
   name                  = "redis"
   private_dns_zone_name = azurerm_private_dns_zone.redis[0].name
   virtual_network_id    = var.virtual_network_id

--- a/modules/redis/variables.tf
+++ b/modules/redis/variables.tf
@@ -51,3 +51,8 @@ variable "key_vault_id" {
   description = "The ID of the Key Vault where Redis secrets will be stored"
   type        = string
 }
+
+variable "redis_private_dns_zone_id" {
+  description = "id of private dns zone for redis if it's already exists"
+  type        = string
+}

--- a/modules/redis/variables.tf
+++ b/modules/redis/variables.tf
@@ -52,7 +52,8 @@ variable "key_vault_id" {
   type        = string
 }
 
-variable "redis_private_dns_zone_id" {
-  description = "id of private dns zone for redis if it's already exists"
+variable "existing_redis_private_dns_zone_id" {
+  description = "Advanced: Use an existing private dns zone id for redis private endpoint. Only needed if you want to deploy two data planes into the same VNet. Leave blank to auto-create one."
   type        = string
+  default     = ""
 }

--- a/modules/storage/main.tf
+++ b/modules/storage/main.tf
@@ -102,13 +102,13 @@ resource "azurerm_storage_container" "code_bundles" {
 }
 
 resource "azurerm_private_dns_zone" "blob" {
-  count               = var.blob_private_dns_zone_id == "" ? 1 : 0
+  count               = var.existing_blob_private_dns_zone_id == "" ? 1 : 0
   name                = local.private_dns_zone_name
   resource_group_name = var.resource_group_name
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "blob" {
-  count                 = var.blob_private_dns_zone_id == "" ? 1 : 0
+  count                 = var.existing_blob_private_dns_zone_id == "" ? 1 : 0
   name                  = "${local.storage_account_name}-link"
   resource_group_name   = var.resource_group_name
   private_dns_zone_name = azurerm_private_dns_zone.blob[0].name
@@ -129,7 +129,7 @@ resource "azurerm_private_endpoint" "storage" {
   }
   private_dns_zone_group {
     name                 = "default"
-    private_dns_zone_ids = [var.blob_private_dns_zone_id != "" ? var.blob_private_dns_zone_id : azurerm_private_dns_zone.blob[0].id]
+    private_dns_zone_ids = [var.existing_blob_private_dns_zone_id != "" ? var.existing_blob_private_dns_zone_id : azurerm_private_dns_zone.blob[0].id]
   }
 
   depends_on = [

--- a/modules/storage/main.tf
+++ b/modules/storage/main.tf
@@ -102,14 +102,16 @@ resource "azurerm_storage_container" "code_bundles" {
 }
 
 resource "azurerm_private_dns_zone" "blob" {
+  count               = var.blob_private_dns_zone_id == "" ? 1 : 0
   name                = local.private_dns_zone_name
   resource_group_name = var.resource_group_name
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "blob" {
+  count                 = var.blob_private_dns_zone_id == "" ? 1 : 0
   name                  = "${local.storage_account_name}-link"
   resource_group_name   = var.resource_group_name
-  private_dns_zone_name = azurerm_private_dns_zone.blob.name
+  private_dns_zone_name = azurerm_private_dns_zone.blob[0].name
   virtual_network_id    = var.vnet_id
 }
 
@@ -127,7 +129,7 @@ resource "azurerm_private_endpoint" "storage" {
   }
   private_dns_zone_group {
     name                 = "default"
-    private_dns_zone_ids = [azurerm_private_dns_zone.blob.id]
+    private_dns_zone_ids = [var.blob_private_dns_zone_id != "" ? var.blob_private_dns_zone_id : azurerm_private_dns_zone.blob[0].id]
   }
 
   depends_on = [

--- a/modules/storage/variables.tf
+++ b/modules/storage/variables.tf
@@ -34,7 +34,8 @@ variable "create_storage_container" {
   default     = true
 }
 
-variable "blob_private_dns_zone_id" {
-  description = "id of private dns zone for blob storage if it's already exists"
+variable "existing_blob_private_dns_zone_id" {
+  description = "Advanced: Use an existing private dns zone id for blob storage private endpoint. Only needed if you want to deploy two data planes into the same VNet. Leave blank to auto-create one."
   type        = string
+  default     = ""
 }

--- a/modules/storage/variables.tf
+++ b/modules/storage/variables.tf
@@ -33,3 +33,8 @@ variable "create_storage_container" {
   type        = bool
   default     = true
 }
+
+variable "blob_private_dns_zone_id" {
+  description = "id of private dns zone for blob storage if it's already exists"
+  type        = string
+}

--- a/variables.tf
+++ b/variables.tf
@@ -73,20 +73,25 @@ variable "private_endpoint_subnet_cidr" {
   default     = null
 }
 
+
 variable "pg_private_dns_zone_id" {
   description = "private dns zone id for pg if it's already exists"
   type        = string
+  default     = ""
 }
 
 variable "blob_private_dns_zone_id" {
   description = "private dns zone id for blob if it's already exists"
   type        = string
+  default     = ""
 }
 
 variable "redis_private_dns_zone_id" {
   description = "private dns zone id for redis if it's already exists"
   type        = string
+  default     = ""
 }
+
 
 ## AKS
 variable "create_aks_cluster" {

--- a/variables.tf
+++ b/variables.tf
@@ -73,6 +73,21 @@ variable "private_endpoint_subnet_cidr" {
   default     = null
 }
 
+variable "pg_private_dns_zone_id" {
+  description = "private dns zone id for pg if it's already exists"
+  type        = string
+}
+
+variable "blob_private_dns_zone_id" {
+  description = "private dns zone id for blob if it's already exists"
+  type        = string
+}
+
+variable "redis_private_dns_zone_id" {
+  description = "private dns zone id for redis if it's already exists"
+  type        = string
+}
+
 ## AKS
 variable "create_aks_cluster" {
   description = "Create an AKS cluster"

--- a/variables.tf
+++ b/variables.tf
@@ -74,20 +74,20 @@ variable "private_endpoint_subnet_cidr" {
 }
 
 
-variable "pg_private_dns_zone_id" {
-  description = "private dns zone id for pg if it's already exists"
+variable "existing_postgres_private_dns_zone_id" {
+  description = "Advanced: Use an existing private dns zone id for postgres private endpoint. Only needed if you want to deploy two data planes into the same VNet."
   type        = string
   default     = ""
 }
 
-variable "blob_private_dns_zone_id" {
-  description = "private dns zone id for blob if it's already exists"
+variable "existing_blob_private_dns_zone_id" {
+  description = "Advanced: Use an existing private dns zone id for blob storage private endpoint. Only needed if you want to deploy two data planes into the same VNet."
   type        = string
   default     = ""
 }
 
-variable "redis_private_dns_zone_id" {
-  description = "private dns zone id for redis if it's already exists"
+variable "existing_redis_private_dns_zone_id" {
+  description = "Advanced: Use an existing private dns zone id for redis private endpoint. Only needed if you want to deploy two data planes into the same VNet."
   type        = string
   default     = ""
 }


### PR DESCRIPTION
For Azure BT users who want to create multiple BT deployments using the same vnet and private DNS zones.

This should be backward compatible with existing Azure BT users.